### PR TITLE
Intheleed ajoute la localisation i18n et fixe le bug #79

### DIFF
--- a/intheleed/intheleed.plugin.disabled.php
+++ b/intheleed/intheleed.plugin.disabled.php
@@ -4,7 +4,7 @@
 @author GAULUPEAU Jonathan <jo.gaulupeau@gmail.com>
 @link https://bitbucket.org/jogaulupeau
 @licence GPLv3
-@version 1.0.1
+@version 1.0.2
 @description Le plugin intheleed permet de stocker un lien dans son <a target="_blank" href="http://inthepoche.com">poche</a>. Plugin basé sur un sharleed par Idleman.
 */
 
@@ -52,6 +52,9 @@ function intheleed_plugin_setting_bloc(&$myUser){
 }
 
 function intheleed_plugin_update($_){
+	$myUser = (isset($_SESSION['currentUser'])?unserialize($_SESSION['currentUser']):false);
+	if($myUser===false) exit(_t('P_INTHELEED_CONNECTION_ERROR'));
+	
 	if($_['action']=='intheleed_update'){
         $configurationManager = new Configuration();
         $configurationManager->put('plugin_poche_link',$_['plugin_poche_link']);

--- a/intheleed/intheleed.plugin.disabled.php
+++ b/intheleed/intheleed.plugin.disabled.php
@@ -22,13 +22,13 @@ function intheleed_plugin_button(&$event){
 	$title = $result[1];
   
 	echo '
-	<a title="partager sur poche" target="_blank" href="'.$shareOption.'?action=add&url='.base64_encode($link).'">Poche !</a>
+	<a title="'._t('P_INTHELEED_SHARE_WITH_POCHE').'" target="_blank" href="'.$shareOption.'?action=add&url='.base64_encode($link).'">'._t('P_INTHELEED_POCHE_EXCLAMATION').'</a>
 	';
 }
 
 function intheleed_plugin_setting_link(&$myUser){
 	echo '
-	<li class="pointer" onclick="$(\'#main section\').hide();$(\'#main #pocheBloc\').fadeToggle(200);">poche</li>
+	<li class="pointer" onclick="$(\'#main section\').hide();$(\'#main #pocheBloc\').fadeToggle(200);">'._t('P_INTHELEED_POCHE').'</li>
 	';
 }
 
@@ -38,14 +38,14 @@ function intheleed_plugin_setting_bloc(&$myUser){
 	echo '
 	<section id="pocheBloc" style="display:none;">
 		<form action="action.php?action=intheleed_update" method="POST">
-		<h2>Plugin poche</h2>
+		<h2>'._t('P_INTHELEED_PLUGIN_TITLE').'</h2>
 		<p class="pocheBlock">
-		<label for="plugin_poche_link">Lien vers votre poche :</label> 
+		<label for="plugin_poche_link">'._t('P_INTHELEED_POCHE_LINK').'</label> 
 		<input style="width:50%;" type="text" placeholder="http://poche.mondomaine.com" value="'.$configurationManager->get('plugin_poche_link').'" id="plugin_poche_link" name="plugin_poche_link" />
-		<input type="submit" class="button" value="Enregistrer"><br/>
+		<input type="submit" class="button" value="'._t('P_INTHELEED_SAVE').'"><br/>
 		</p>
 		
-		<strong>Nb:</strong> cette option affichera un bouton à côté de chaque article pour vous proposer de le stocker sur poche.
+		<strong>'._t('P_INTHELEED_NB').'</strong> '._t('P_INTHELEED_NB_INFO').'
 		</form>
 	</section>
 	';

--- a/intheleed/locale/en.json
+++ b/intheleed/locale/en.json
@@ -1,0 +1,11 @@
+{
+"P_INTHELEED_SHARE_WITH_POCHE":"Share with Poche",
+"P_INTHELEED_POCHE_EXCLAMATION":"Poche !",
+"P_INTHELEED_POCHE":"poche",
+"P_INTHELEED_PLUGIN_TITLE":"Poche plugin",
+"P_INTHELEED_POCHE_LINK":"Your Poche link :",
+"P_INTHELEED_SAVE":"Save",
+"P_INTHELEED_NB":"NB:",
+"P_INTHELEED_NB_INFO":"This option will display a button beside every news to save it on your Poche service.",
+"P_INTHELEED_CONNECTION_ERROR":"You have to be logged for this action."
+}

--- a/intheleed/locale/fr.json
+++ b/intheleed/locale/fr.json
@@ -1,0 +1,11 @@
+{
+"P_INTHELEED_SHARE_WITH_POCHE":"partager sur poche",
+"P_INTHELEED_POCHE_EXCLAMATION":"Poche !",
+"P_INTHELEED_POCHE":"poche",
+"P_INTHELEED_PLUGIN_TITLE":"Plugin poche",
+"P_INTHELEED_POCHE_LINK":"Lien vers votre poche :",
+"P_INTHELEED_SAVE":"Enregistrer",
+"P_INTHELEED_NB":"NB:",
+"P_INTHELEED_NB_INFO":"Cette option affichera un bouton à côté de chaque article pour vous proposer de le stocker sur poche.",
+"P_INTHELEED_CONNECTION_ERROR":"Vous devez être connecté pour cette action."
+}


### PR DESCRIPTION
Ces corrections devraient fonctionner, mais je n'ai pas de service Poche à disposition pour tester.

PS: Devrait-on remplacer le terme "Poche" par "Wallabag" suite aux différents avec Pocket(TM) ?